### PR TITLE
fix: org tree mobile layout + desktop overflow (#31, #32)

### DIFF
--- a/packages/dashboard/src/client/components/org/AgentNode.tsx
+++ b/packages/dashboard/src/client/components/org/AgentNode.tsx
@@ -6,25 +6,52 @@ interface AgentNodeProps {
   state?: Agent;
   selected: boolean;
   onClick: () => void;
+  compact?: boolean;
 }
 
-export function AgentNode({ orgAgent, state, selected, onClick }: AgentNodeProps) {
+export function AgentNode({ orgAgent, state, selected, onClick, compact }: AgentNodeProps) {
   const status = state?.status ?? 'idle';
   const lastActive = state?.lastInvocation;
+
+  if (compact) {
+    return (
+      <button
+        onClick={onClick}
+        className={`w-full px-3 py-2 rounded-lg border transition-all text-left cursor-pointer ${
+          selected
+            ? 'bg-amber-500/10 border-amber-500'
+            : 'bg-slate-900 border-slate-800 hover:border-slate-700'
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-base shrink-0">{orgAgent.emoji ?? '\u25B9'}</span>
+          <span className="text-sm font-medium text-slate-200 truncate">{orgAgent.name}</span>
+          <StatusDot status={status} />
+          <span className="text-xs text-slate-500">{status}</span>
+          {orgAgent.role && (
+            <span className="text-[11px] text-slate-500 truncate ml-auto hidden min-[420px]:inline">{orgAgent.role}</span>
+          )}
+        </div>
+      </button>
+    );
+  }
 
   return (
     <button
       onClick={onClick}
-      className={`px-3 py-2 md:px-4 md:py-3 rounded-lg border transition-all text-left min-w-[120px] md:min-w-[140px] ${
+      className={`px-4 py-3 rounded-lg border transition-all text-left min-w-[140px] cursor-pointer ${
         selected
           ? 'bg-amber-500/10 border-amber-500'
           : 'bg-slate-900 border-slate-800 hover:border-slate-700'
       }`}
     >
-      <div className="flex items-center gap-2 mb-1">
+      <div className="flex items-center gap-2 mb-0.5">
         <span className="text-base">{orgAgent.emoji ?? '\u25B9'}</span>
         <span className="text-sm font-medium text-slate-200 truncate">{orgAgent.name}</span>
       </div>
+      {orgAgent.role && (
+        <p className="text-[11px] text-slate-500 ml-7 truncate">{orgAgent.role}</p>
+      )}
       <div className="flex items-center gap-1">
         <StatusDot status={status} />
         <span className="text-xs text-slate-500">{status}</span>

--- a/packages/dashboard/src/client/components/org/OrgTree.tsx
+++ b/packages/dashboard/src/client/components/org/OrgTree.tsx
@@ -12,7 +12,8 @@ export function OrgTree({ org, agents, selectedAgentId, onSelectAgent }: OrgTree
   const agentMap = new Map(org.agents.map(a => [a.id, a]));
   const stateMap = new Map(agents.map(a => [a.id, a]));
 
-  function renderNode(id: string): React.ReactNode {
+  /** Desktop: horizontal tree layout (unchanged structure, with min-width preservation) */
+  function renderTreeNode(id: string): React.ReactNode {
     const orgAgent = agentMap.get(id);
     if (!orgAgent) return null;
 
@@ -29,7 +30,7 @@ export function OrgTree({ org, agents, selectedAgentId, onSelectAgent }: OrgTree
         {children.length > 0 && (
           <>
             <div className="w-px h-6 bg-slate-700" />
-            <div className="flex gap-3 md:gap-6 relative">
+            <div className="flex gap-6 relative">
               {children.length > 1 && (
                 <div className="absolute top-0 left-1/2 -translate-x-1/2 h-px bg-slate-700" style={{
                   width: `calc(100% - 120px)`,
@@ -38,7 +39,7 @@ export function OrgTree({ org, agents, selectedAgentId, onSelectAgent }: OrgTree
               {children.map(childId => (
                 <div key={childId} className="flex flex-col items-center">
                   {children.length > 1 && <div className="w-px h-6 bg-slate-700" />}
-                  {renderNode(childId)}
+                  {renderTreeNode(childId)}
                 </div>
               ))}
             </div>
@@ -48,9 +49,62 @@ export function OrgTree({ org, agents, selectedAgentId, onSelectAgent }: OrgTree
     );
   }
 
+  /** Mobile: vertical indented list */
+  function renderListNode(id: string, depth: number): React.ReactNode {
+    const orgAgent = agentMap.get(id);
+    if (!orgAgent) return null;
+
+    const children = orgAgent.childIds;
+
+    return (
+      <div key={id}>
+        <div
+          className="relative"
+          style={{ paddingLeft: `${depth * 24}px` }}
+        >
+          {/* Vertical connector line from parent */}
+          {depth > 0 && (
+            <div
+              className="absolute top-0 bottom-1/2 w-px bg-slate-700"
+              style={{ left: `${(depth - 1) * 24 + 12}px` }}
+            />
+          )}
+          {/* Horizontal connector to this node */}
+          {depth > 0 && (
+            <div
+              className="absolute top-1/2 h-px bg-slate-700"
+              style={{ left: `${(depth - 1) * 24 + 12}px`, width: '12px' }}
+            />
+          )}
+          <div className="py-1">
+            <AgentNode
+              orgAgent={orgAgent}
+              state={stateMap.get(id)}
+              selected={selectedAgentId === id}
+              onClick={() => onSelectAgent(id)}
+              compact
+            />
+          </div>
+        </div>
+        {children.map(childId => renderListNode(childId, depth + 1))}
+      </div>
+    );
+  }
+
   return (
-    <div className="flex justify-center py-4 md:py-8 overflow-x-auto">
-      {renderNode(org.root)}
-    </div>
+    <>
+      {/* Mobile: vertical indented list */}
+      <div className="block md:hidden py-4">
+        {renderListNode(org.root, 0)}
+      </div>
+      {/* Desktop: horizontal tree with scroll */}
+      <div className="hidden md:block py-8 overflow-x-auto">
+        <div className="w-fit min-w-full px-4">
+          <div className="flex justify-center">
+            {renderTreeNode(org.root)}
+          </div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/packages/dashboard/src/client/index.css
+++ b/packages/dashboard/src/client/index.css
@@ -9,7 +9,7 @@ body {
   font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
 }
 
-::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: #475569; border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: #64748b; }

--- a/packages/dashboard/src/client/pages/OrgPage.tsx
+++ b/packages/dashboard/src/client/pages/OrgPage.tsx
@@ -22,7 +22,7 @@ export function OrgPage() {
   return (
     <div className="flex flex-col md:flex-row h-full -m-3 md:-m-6">
       {/* Tree view: hidden on mobile when detail panel is open */}
-      <div className={`flex-1 overflow-auto p-3 md:p-6 ${selectedAgentId ? 'hidden md:block' : ''}`}>
+      <div className={`flex-1 min-w-0 overflow-auto p-3 md:p-6 ${selectedAgentId ? 'hidden md:block' : ''}`}>
         <h2 className="text-lg font-medium text-slate-200 mb-4">Organization</h2>
         <OrgTree
           org={org}


### PR DESCRIPTION
## Summary
- **#32 (P0 Critical)**: Org tree completely unusable on mobile — replaced horizontal tree with vertical indented list layout. All 12 agents visible and tappable with clear hierarchy via indentation. Detail panel uses full screen with back navigation.
- **#31 (P1 Major)**: Org tree overflows/clips on desktop and nodes compress to unreadable when detail panel opens — tree container now uses `w-fit` to prevent compression. Nodes maintain min-width and scroll horizontally with a visible, styled scrollbar.
- Added compact `AgentNode` variant for mobile list view
- Added `cursor-pointer` to all interactive agent nodes
- Styled horizontal scrollbar for visibility (`height: 6px`)

## Test plan
- [x] Vite build passes
- [x] All existing tests pass (1 pre-existing failure in spawner.test.ts, unrelated)
- [x] Mobile (375px): vertical list shows all 12 agents, tapping opens full-screen detail panel with back button
- [x] Desktop (1280px): full tree visible without panel, scrollbar visible with panel open, nodes maintain readable size
- [x] Desktop (1920px): full tree fits without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)