### PR TITLE
fix: Per-Agent Breakdown zeros + channel raw IDs (#37, #35)

### DIFF
--- a/packages/dashboard/src/client/components/audit/CostChart.tsx
+++ b/packages/dashboard/src/client/components/audit/CostChart.tsx
@@ -1,12 +1,15 @@
 import { useApi } from '../../hooks/useApi';
 import type { Agent } from '../../types';
 
+type AgentTotalsMap = Record<string, { totalIn: number; totalOut: number }>;
+
 export function CostChart({ agents }: { agents: Agent[] }) {
-  // Fetch per-agent totals
-  const agentTotals = agents.map(a => {
-    const { data } = useApi<{ totalIn: number; totalOut: number }>(`/api/audit/totals?agentId=${a.id}`);
-    return { agent: a, totals: data };
-  });
+  const { data: totalsMap } = useApi<AgentTotalsMap>('/api/audit/agent-totals', { refreshInterval: 5000 });
+
+  const agentTotals = agents.map(a => ({
+    agent: a,
+    totals: totalsMap?.[a.id] ?? null,
+  }));
 
   const maxTotal = Math.max(
     ...agentTotals.map(at => (at.totals?.totalIn ?? 0) + (at.totals?.totalOut ?? 0)),
@@ -22,8 +25,9 @@ export function CostChart({ agents }: { agents: Agent[] }) {
           const pct = total > 0 ? (total / maxTotal) * 100 : 0;
           return (
             <div key={agent.id} className="flex items-center gap-3">
-              <span className="text-sm w-24 truncate text-slate-300">
+              <span className="text-sm w-40 truncate text-slate-300" title={agent.role ? `${agent.name}, ${agent.role}` : agent.name}>
                 {agent.emoji ?? '\u25B9'} {agent.name}
+                {agent.role && <span className="text-slate-600 text-[11px] ml-1">{agent.role}</span>}
               </span>
               <div className="flex-1 bg-slate-800 rounded-full h-2.5 overflow-hidden">
                 <div

--- a/packages/dashboard/src/client/components/channels/ChannelList.tsx
+++ b/packages/dashboard/src/client/components/channels/ChannelList.tsx
@@ -1,5 +1,6 @@
 import { useApi } from '../../hooks/useApi';
-import type { Channel } from '../../types';
+import { formatChannelName } from '../shared';
+import type { Channel, Agent } from '../../types';
 
 interface ChannelListProps {
   selectedChannel: string | null;
@@ -8,6 +9,9 @@ interface ChannelListProps {
 
 export function ChannelList({ selectedChannel, onSelectChannel }: ChannelListProps) {
   const { data: channels } = useApi<Channel[]>('/api/channels');
+  const { data: agents } = useApi<Agent[]>('/api/agents');
+
+  const agentMap = new Map(agents?.map(a => [a.id, a]) ?? []);
 
   return (
     <div className="w-full md:w-56 border-r border-slate-800 flex flex-col shrink-0">
@@ -19,14 +23,14 @@ export function ChannelList({ selectedChannel, onSelectChannel }: ChannelListPro
           <button
             key={ch.name}
             onClick={() => onSelectChannel(ch.name)}
-            className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+            className={`w-full text-left px-4 py-2 text-sm transition-colors cursor-pointer ${
               selectedChannel === ch.name
                 ? 'bg-slate-800 text-amber-500'
                 : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-200'
             }`}
           >
-            <span className="font-mono">#{ch.name}</span>
-            <span className="text-xs text-slate-600 ml-2">{ch.messageCount}</span>
+            <span>{formatChannelName(ch.name, agentMap)}</span>
+            <span className="text-xs text-slate-600 ml-2">{ch.messageCount} msgs</span>
           </button>
         ))}
         {channels?.length === 0 && (

--- a/packages/dashboard/src/client/components/home/ChannelActivityCard.tsx
+++ b/packages/dashboard/src/client/components/home/ChannelActivityCard.tsx
@@ -1,7 +1,7 @@
 import { useApi } from '../../hooks/useApi';
 import { useSSEEvent } from '../../hooks/useSSE';
-import { DashboardCard, timeAgo } from '../shared';
-import type { Channel, Message } from '../../types';
+import { DashboardCard, timeAgo, formatChannelName } from '../shared';
+import type { Channel, Message, Agent } from '../../types';
 import { useEffect, useState, useCallback } from 'react';
 
 interface ChannelPreview {
@@ -11,7 +11,9 @@ interface ChannelPreview {
 
 export function ChannelActivityCard() {
   const { data: channels } = useApi<Channel[]>('/api/channels');
+  const { data: agents } = useApi<Agent[]>('/api/agents');
   const [previews, setPreviews] = useState<ChannelPreview[]>([]);
+  const agentMap = new Map(agents?.map(a => [a.id, a]) ?? []);
 
   useEffect(() => {
     if (!channels) return;
@@ -58,7 +60,7 @@ export function ChannelActivityCard() {
             return (
               <div key={p.name} className="text-xs">
                 <div className="flex items-center gap-1.5">
-                  <span className="text-amber-500 font-mono">#{p.name}</span>
+                  <span className="text-amber-500">{formatChannelName(p.name, agentMap)}</span>
                   {lastMsg && (
                     <span className="text-slate-600 ml-auto">{timeAgo(lastMsg.timestamp)}</span>
                   )}

--- a/packages/dashboard/src/client/components/shared.tsx
+++ b/packages/dashboard/src/client/components/shared.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import type { Agent } from '../types';
 
 export function EmptyState({ message }: { message: string }) {
   return (
@@ -53,4 +54,17 @@ export function timeAgo(dateStr: string | undefined): string {
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h ago`;
   return `${Math.floor(h / 24)}d ago`;
+}
+
+/** Convert a channel name (e.g. "dm:sam") to a human-readable display name using the agent map. */
+export function formatChannelName(channelName: string, agentMap?: Map<string, Agent>): string {
+  if (channelName.startsWith('dm:')) {
+    const alias = channelName.slice(3);
+    if (agentMap) {
+      const agent = agentMap.get(alias);
+      if (agent) return `${agent.emoji ?? '\u25B9'} ${agent.name}`;
+    }
+    return alias;
+  }
+  return `# ${channelName}`;
 }

--- a/packages/dashboard/src/client/pages/ChannelsPage.tsx
+++ b/packages/dashboard/src/client/pages/ChannelsPage.tsx
@@ -1,9 +1,14 @@
 import { useState } from 'react';
 import { ChannelList } from '../components/channels/ChannelList';
 import { ChannelFeed } from '../components/channels/ChannelFeed';
+import { useApi } from '../hooks/useApi';
+import { formatChannelName } from '../components/shared';
+import type { Agent } from '../types';
 
 export function ChannelsPage() {
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
+  const { data: agents } = useApi<Agent[]>('/api/agents');
+  const agentMap = new Map(agents?.map(a => [a.id, a]) ?? []);
 
   return (
     <div className="flex flex-col md:flex-row h-full -m-3 md:-m-6">
@@ -24,7 +29,7 @@ export function ChannelsPage() {
               >
                 &larr; Back
               </button>
-              <h2 className="text-lg font-medium text-slate-200 font-mono">#{selectedChannel}</h2>
+              <h2 className="text-lg font-medium text-slate-200">{formatChannelName(selectedChannel, agentMap)}</h2>
             </div>
             <div className="flex-1 overflow-auto">
               <ChannelFeed channel={selectedChannel} />

--- a/packages/dashboard/src/server/routes/audit.ts
+++ b/packages/dashboard/src/server/routes/audit.ts
@@ -27,5 +27,11 @@ export function createAuditRoutes(ctx: HiveContext): Router {
     res.json(totals);
   });
 
+  // GET /api/audit/agent-totals — token totals grouped by agent (single query)
+  router.get('/agent-totals', (_req, res) => {
+    const totals = ctx.audit.getTokenTotalsByAgent();
+    res.json(totals);
+  });
+
   return router;
 }

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -148,6 +148,17 @@ export class AuditStore {
     return { totalIn: row.total_in, totalOut: row.total_out };
   }
 
+  getTokenTotalsByAgent(): Record<string, { totalIn: number; totalOut: number }> {
+    const rows = this.db.prepare(
+      'SELECT agent_id, COALESCE(SUM(tokens_in), 0) as total_in, COALESCE(SUM(tokens_out), 0) as total_out FROM invocations GROUP BY agent_id'
+    ).all() as Array<{ agent_id: string; total_in: number; total_out: number }>;
+    const result: Record<string, { totalIn: number; totalOut: number }> = {};
+    for (const row of rows) {
+      result[row.agent_id] = { totalIn: row.total_in, totalOut: row.total_out };
+    }
+    return result;
+  }
+
   close(): void {
     this.db.close();
   }


### PR DESCRIPTION
## Summary
- **#37 (P1 Major)**: Per-Agent Breakdown shows all zeros on page navigation. Root cause: `useApi` hooks called inside `.map()` violated React's rules of hooks. Fix: Added batch `/api/audit/agent-totals` endpoint (single `GROUP BY` query) and replaced N hook calls with one `useApi` call with 5s refresh.
- **#35 (P1 Major)**: Channel list shows raw technical IDs (`dm:sam`, `dm:hiro`) instead of human-readable names. Fix: Added `formatChannelName()` utility that resolves DM channels to agent display names with emoji. Applied across ChannelList sidebar, ChannelsPage header, and Home page ChannelActivityCard.

## Test plan
- [x] Vite build passes
- [x] All 432 tests pass
- [x] Per-Agent Breakdown shows non-zero token totals on initial load and page navigation
- [x] Channel names show human-readable names with emoji (e.g., "📋 Sam Rivera" instead of "#dm:sam")
- [x] Message count labels added to channel list items

🤖 Generated with [Claude Code](https://claude.com/claude-code)