### PR TITLE
fix: prevent text truncation on mobile sidebar, cards, and channel list (#45)

### DIFF
--- a/packages/dashboard/src/client/components/conversations/ConversationList.tsx
+++ b/packages/dashboard/src/client/components/conversations/ConversationList.tsx
@@ -29,8 +29,10 @@ export function ConversationList({ selectedConversation, onSelectConversation }:
                 : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-200'
             }`}
           >
-            <span>{formatConversationName(ch.name, agentMap, ch.members, ch.displayName)}</span>
-            <span className="text-xs text-slate-600 ml-2">{ch.messageCount} msgs</span>
+            <span className="flex items-center min-w-0">
+              <span className="truncate">{formatConversationName(ch.name, agentMap, ch.members, ch.displayName)}</span>
+              <span className="text-xs text-slate-600 ml-2 shrink-0">{ch.messageCount} msgs</span>
+            </span>
           </button>
         ))}
         {conversations?.length === 0 && (

--- a/packages/dashboard/src/client/components/layout/Sidebar.tsx
+++ b/packages/dashboard/src/client/components/layout/Sidebar.tsx
@@ -34,8 +34,8 @@ export function Sidebar({ onNavigate }: SidebarProps) {
               }`
             }
           >
-            <span className="text-base">{link.icon}</span>
-            {link.label}
+            <span className="text-base shrink-0">{link.icon}</span>
+            <span className="truncate">{link.label}</span>
           </NavLink>
         ))}
       </div>

--- a/packages/dashboard/src/client/components/shared.tsx
+++ b/packages/dashboard/src/client/components/shared.tsx
@@ -20,8 +20,8 @@ export function DashboardCard({ title, icon, linkTo, children }: {
       to={linkTo}
       className="block bg-slate-900 border border-slate-800 rounded-lg p-4 hover:border-slate-700 transition-colors"
     >
-      <h3 className="text-sm font-medium text-slate-400 mb-3">
-        <span className="mr-2">{icon}</span>{title}
+      <h3 className="text-sm font-medium text-slate-400 mb-3 flex items-center min-w-0">
+        <span className="mr-2 shrink-0">{icon}</span><span className="truncate">{title}</span>
       </h3>
       {children}
     </Link>


### PR DESCRIPTION
## Summary
- **Sidebar.tsx**: Nav link labels now wrapped in `<span className="truncate">` with `shrink-0` on icon to prevent label clipping on narrow viewports
- **shared.tsx**: DashboardCard `<h3>` title converted to flex layout with `min-w-0` and `truncate` on title text, `shrink-0` on icon
- **ChannelList.tsx**: Channel name and message count wrapped in flex container with `truncate` on name and `shrink-0` on count badge

## Root cause
Text elements in flex containers lacked overflow constraints. On mobile viewports (≤375px), long nav labels, card titles, and channel names overflowed their containers instead of showing ellipsis.

## Test plan
- [ ] Verify sidebar nav labels show ellipsis at 320px viewport width
- [ ] Verify DashboardCard titles truncate properly on mobile
- [ ] Verify channel list names truncate with message count remaining visible
- [ ] Verify no visual regression at 768px, 1024px, 1440px
- [ ] Vite build passes cleanly (verified locally)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)