### PR TITLE
fix: add error handling to chat message send

### DIFF
--- a/packages/dashboard/src/client/components/chat/ChatInput.tsx
+++ b/packages/dashboard/src/client/components/chat/ChatInput.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 
 interface ChatInputProps {
-  onSend: (text: string) => void;
+  onSend: (text: string) => Promise<boolean> | void;
   disabled: boolean;
   rootName?: string;
 }
@@ -14,13 +14,16 @@ export function ChatInput({ onSend, disabled, rootName = 'CEO' }: ChatInputProps
     inputRef.current?.focus();
   }, []);
 
+  const submit = async () => {
+    if (!text.trim() || disabled) return;
+    const result = await onSend(text.trim());
+    if (result !== false) setText('');
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (text.trim() && !disabled) {
-        onSend(text.trim());
-        setText('');
-      }
+      submit();
     }
   };
 
@@ -37,7 +40,7 @@ export function ChatInput({ onSend, disabled, rootName = 'CEO' }: ChatInputProps
           className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 resize-none focus:outline-none focus:border-amber-500 transition-colors"
         />
         <button
-          onClick={() => { if (text.trim()) { onSend(text.trim()); setText(''); } }}
+          onClick={submit}
           disabled={disabled || !text.trim()}
           className="px-4 py-2.5 bg-amber-500 text-slate-950 text-sm rounded-lg font-medium disabled:opacity-50 hover:bg-amber-400 transition-colors shrink-0"
         >

--- a/packages/dashboard/src/client/pages/ChatPage.tsx
+++ b/packages/dashboard/src/client/pages/ChatPage.tsx
@@ -13,6 +13,7 @@ export function ChatPage() {
   );
   const [rootWorking, setRootWorking] = useState(false);
   const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
 
   useSSEEvent('new-message', useCallback((event: any) => {
     if (conversation && event.conversation === conversation) {
@@ -39,14 +40,24 @@ export function ChatPage() {
 
   const rootName = meta?.rootName ?? 'CEO';
 
-  const sendMessage = async (text: string) => {
+  const sendMessage = async (text: string): Promise<boolean> => {
     setSending(true);
+    setSendError(null);
     try {
-      await fetch('/api/chat', {
+      const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text }),
       });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        setSendError(body || `Send failed (HTTP ${res.status})`);
+        return false;
+      }
+      return true;
+    } catch {
+      setSendError('Network error — message not sent. Please try again.');
+      return false;
     } finally {
       setSending(false);
     }
@@ -59,6 +70,17 @@ export function ChatPage() {
         <p className="text-xs text-slate-500 font-mono">Direct message</p>
       </div>
       <ChatFeed messages={messages ?? []} rootWorking={rootWorking} rootName={rootName} />
+      {sendError && (
+        <div className="mx-4 mb-2 px-4 py-2.5 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center justify-between gap-3">
+          <p className="text-sm text-red-400">{sendError}</p>
+          <button
+            onClick={() => setSendError(null)}
+            className="text-red-400 hover:text-red-300 text-xs shrink-0"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       <ChatInput onSend={sendMessage} disabled={sending} rootName={rootName} />
     </div>
   );


### PR DESCRIPTION
## Summary
- **P0 bug fix**: Chat message send failures in the dashboard were silently swallowed — no error shown, message text lost
- Added `response.ok` check and `catch` block to `sendMessage` in ChatPage — surfaces HTTP errors and network failures
- ChatInput now awaits `onSend` result and only clears the textarea on success, preserving text for retry
- Dismissible error banner appears above the input area on failure

## Test plan
- [ ] Verify existing tests pass (403/403 ✅)
- [ ] Verify dashboard builds cleanly (vite build ✅)
- [ ] Manual: stop backend, send a message → error banner appears, message text preserved
- [ ] Manual: backend returns 500 → error banner shows status, message preserved
- [ ] Manual: dismiss error → banner disappears
- [ ] Manual: successful send → text clears, no error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)