### PR TITLE
fix: add message count indicator to RecentChatCard

### DIFF
--- a/packages/dashboard/src/client/components/conversations/ConversationFeed.tsx
+++ b/packages/dashboard/src/client/components/conversations/ConversationFeed.tsx
@@ -3,23 +3,28 @@ import { useApi } from '../../hooks/useApi';
 import { useSSEEvent } from '../../hooks/useSSE';
 import { ConversationMessage } from './ConversationMessage';
 import { EmptyState } from '../shared';
-import type { Message } from '../../types';
+import type { Message, MessagesResponse } from '../../types';
 
 export function ConversationFeed({ conversation }: { conversation: string }) {
-  const { data: messages, setData } = useApi<Message[]>(`/api/conversations/${conversation}/messages?limit=50`);
+  const { data: messagesData, setData } = useApi<MessagesResponse>(`/api/conversations/${conversation}/messages?limit=50`);
+  const messages = messagesData?.messages;
 
   useSSEEvent('new-message', useCallback((event: any) => {
     if (event.conversation === conversation) {
       setData(prev => {
-        const exists = prev?.some(m => m.id === event.id);
+        const msgs = prev?.messages ?? [];
+        const exists = msgs.some(m => m.id === event.id);
         if (exists) return prev;
-        return [...(prev ?? []), {
-          id: event.id,
-          sender: event.sender,
-          content: event.content,
-          timestamp: event.timestamp,
-          conversation: event.conversation,
-        }];
+        return {
+          messages: [...msgs, {
+            id: event.id,
+            sender: event.sender,
+            content: event.content,
+            timestamp: event.timestamp,
+            conversation: event.conversation,
+          }],
+          total: (prev?.total ?? 0) + 1,
+        };
       });
     }
   }, [conversation, setData]));

--- a/packages/dashboard/src/client/components/home/ConversationActivityCard.tsx
+++ b/packages/dashboard/src/client/components/home/ConversationActivityCard.tsx
@@ -23,7 +23,8 @@ export function ConversationActivityCard() {
       conversations.map(async (ch) => {
         try {
           const res = await fetch(`/api/conversations/${ch.name}/messages?limit=3`);
-          const msgs: Message[] = await res.json();
+          const data = await res.json();
+          const msgs: Message[] = data.messages;
           return { name: ch.name, displayName: ch.displayName, members: ch.members, recentMessages: msgs };
         } catch {
           return { name: ch.name, displayName: ch.displayName, members: ch.members, recentMessages: [] as Message[] };

--- a/packages/dashboard/src/client/components/home/RecentChatCard.tsx
+++ b/packages/dashboard/src/client/components/home/RecentChatCard.tsx
@@ -2,26 +2,31 @@ import { useState, useCallback } from 'react';
 import { useApi } from '../../hooks/useApi';
 import { useSSEEvent } from '../../hooks/useSSE';
 import { DashboardCard, timeAgo } from '../shared';
-import type { Message, OrgMeta } from '../../types';
+import type { MessagesResponse, OrgMeta } from '../../types';
 
 export function RecentChatCard() {
   const { data: meta } = useApi<OrgMeta>('/api/org/meta');
   const conversation = meta?.rootConversation;
-  const { data: messages, setData } = useApi<Message[]>(
+  const { data: messagesData, setData } = useApi<MessagesResponse>(
     conversation ? `/api/conversations/${conversation}/messages?limit=5` : null,
   );
+  const messages = messagesData?.messages;
+  const totalMessages = messagesData?.total ?? 0;
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
 
   useSSEEvent('new-message', useCallback((event: any) => {
     if (conversation && event.conversation === conversation) {
-      setData(prev => [...(prev ?? []).slice(-4), {
-        id: event.id,
-        sender: event.sender,
-        content: event.content,
-        timestamp: event.timestamp,
-        conversation: event.conversation,
-      }]);
+      setData(prev => ({
+        messages: [...(prev?.messages ?? []).slice(-4), {
+          id: event.id,
+          sender: event.sender,
+          content: event.content,
+          timestamp: event.timestamp,
+          conversation: event.conversation,
+        }],
+        total: (prev?.total ?? 0) + 1,
+      }));
     }
   }, [conversation, setData]));
 
@@ -44,7 +49,7 @@ export function RecentChatCard() {
 
   return (
     <DashboardCard title={`${rootName} Chat`} icon={'\u25C9'} linkTo="/chat">
-      <div className="space-y-2 mb-3">
+      <div className="space-y-2 mb-2">
         {messages && messages.length > 0 ? (
           messages.slice(-3).map(m => (
             <div key={m.id} className="text-xs">
@@ -57,6 +62,14 @@ export function RecentChatCard() {
           <p className="text-xs text-slate-500">No messages yet</p>
         )}
       </div>
+      {totalMessages > 3 && (
+        <div className="flex items-center justify-between mb-3 text-xs">
+          <span className="text-slate-500">Showing 3 of {totalMessages} messages</span>
+          <a href="/chat" onClick={(e) => e.stopPropagation()} className="text-amber-500 hover:text-amber-400 transition-colors">
+            View all →
+          </a>
+        </div>
+      )}
       <div className="flex gap-2" onClick={(e) => e.preventDefault()}>
         <input
           type="text"

--- a/packages/dashboard/src/client/pages/ChatPage.tsx
+++ b/packages/dashboard/src/client/pages/ChatPage.tsx
@@ -3,14 +3,15 @@ import { ChatFeed } from '../components/chat/ChatFeed';
 import { ChatInput } from '../components/chat/ChatInput';
 import { useApi } from '../hooks/useApi';
 import { useSSEEvent } from '../hooks/useSSE';
-import type { Message, OrgMeta } from '../types';
+import type { Message, MessagesResponse, OrgMeta } from '../types';
 
 export function ChatPage() {
   const { data: meta } = useApi<OrgMeta>('/api/org/meta');
   const conversation = meta?.rootConversation;
-  const { data: messages, setData } = useApi<Message[]>(
+  const { data: messagesData, setData } = useApi<MessagesResponse>(
     conversation ? `/api/conversations/${conversation}/messages?limit=100` : null,
   );
+  const messages = messagesData?.messages ?? null;
   const [rootWorking, setRootWorking] = useState(false);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
@@ -18,15 +19,19 @@ export function ChatPage() {
   useSSEEvent('new-message', useCallback((event: any) => {
     if (conversation && event.conversation === conversation) {
       setData(prev => {
-        const exists = prev?.some(m => m.id === event.id);
+        const msgs = prev?.messages ?? [];
+        const exists = msgs.some(m => m.id === event.id);
         if (exists) return prev;
-        return [...(prev ?? []), {
-          id: event.id,
-          sender: event.sender,
-          content: event.content,
-          timestamp: event.timestamp,
-          conversation: event.conversation,
-        }];
+        return {
+          messages: [...msgs, {
+            id: event.id,
+            sender: event.sender,
+            content: event.content,
+            timestamp: event.timestamp,
+            conversation: event.conversation,
+          }],
+          total: (prev?.total ?? 0) + 1,
+        };
       });
     }
   }, [conversation, setData]));

--- a/packages/dashboard/src/client/types.ts
+++ b/packages/dashboard/src/client/types.ts
@@ -49,6 +49,11 @@ export interface Message {
   mentions?: string[];
 }
 
+export interface MessagesResponse {
+  messages: Message[];
+  total: number;
+}
+
 export interface Invocation {
   id: string;
   agentId: string;

--- a/packages/dashboard/src/server/__tests__/routes.test.ts
+++ b/packages/dashboard/src/server/__tests__/routes.test.ts
@@ -126,12 +126,15 @@ describe('Dashboard API routes', () => {
     expect(Array.isArray(body)).toBe(true);
   });
 
-  it('GET /api/conversations/:id/messages returns messages array', async () => {
+  it('GET /api/conversations/:id/messages returns messages object with total', async () => {
     const conversationIds = ctx.access.getAccessibleConversations(0);
     const conversationId = conversationIds[0] ?? 'dm:0:1';
     const { status, body } = await request(`/api/conversations/${conversationId}/messages`);
     expect(status).toBe(200);
-    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveProperty('messages');
+    expect(body).toHaveProperty('total');
+    expect(Array.isArray(body.messages)).toBe(true);
+    expect(typeof body.total).toBe('number');
   });
 
   it('GET /api/audit returns invocations array', async () => {

--- a/packages/dashboard/src/server/routes/conversations.ts
+++ b/packages/dashboard/src/server/routes/conversations.ts
@@ -40,13 +40,16 @@ export function createConversationRoutes(ctx: HiveContext): Router {
       const limit = parseInt(req.query.limit as string) || 50;
       const history = ctx.messages.history(conversationId, { limit });
 
-      res.json(history.messages.map(m => ({
-        id: `${m.conversationId}:${m.seq}`,
-        conversation: m.conversationId,
-        sender: m.senderAlias,
-        content: m.content,
-        timestamp: m.timestamp,
-      })));
+      res.json({
+        messages: history.messages.map(m => ({
+          id: `${m.conversationId}:${m.seq}`,
+          conversation: m.conversationId,
+          sender: m.senderAlias,
+          content: m.content,
+          timestamp: m.timestamp,
+        })),
+        total: history.total,
+      });
     } catch (err: any) {
       console.error('[conversations/messages] Error:', err.message);
       res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- **Backend**: Messages endpoint (`GET /api/conversations/:name/messages`) now returns `{ messages, total }` instead of a plain array, exposing the total message count from the existing `history.total` query
- **Frontend**: RecentChatCard displays "Showing 3 of N messages" with a "View all →" link to `/chat` when total exceeds 3 displayed messages
- **All consumers updated**: ChatPage, ConversationFeed, ConversationActivityCard adapted for new response shape

Fixes board-reported bug: users thought conversations were short because only 3 messages displayed with no indication of older messages.

## Test plan
- [x] Routes test updated to verify new `{ messages, total }` response shape
- [x] All 401 tests pass (2 pre-existing failures in `tests/chat/e2e.test.ts` unrelated)
- [ ] Manual: verify "Showing 3 of N messages" appears on home page when conversation has >3 messages
- [ ] Manual: verify "View all →" navigates to `/chat`
- [ ] Manual: verify ConversationFeed and ConversationActivityCard still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)