### PR TITLE
fix: include missing fields in audit SSE events

### DIFF
--- a/packages/dashboard/src/server/index.ts
+++ b/packages/dashboard/src/server/index.ts
@@ -164,8 +164,12 @@ function wireEventBus(ctx: HiveContext, bus: HiveEventBus, daemon: Daemon | null
       model: opts.model,
       tokensIn: opts.tokensIn,
       tokensOut: opts.tokensOut,
+      cacheReadTokens: opts.cacheReadTokens,
+      cacheCreationTokens: opts.cacheCreationTokens,
       durationMs: opts.durationMs,
       channel: opts.channel,
+      inputSummary: opts.inputSummary,
+      outputSummary: opts.outputSummary,
     });
     return id;
   };

--- a/src/events/event-bus.ts
+++ b/src/events/event-bus.ts
@@ -24,8 +24,12 @@ export interface AuditInvocationEvent {
   model: string;
   tokensIn?: number;
   tokensOut?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   durationMs?: number;
   channel?: string;
+  inputSummary?: string;
+  outputSummary?: string;
 }
 
 export interface HiveEventMap {


### PR DESCRIPTION
## Summary
- The audit page SSE stream (`audit:invocation` event) was only emitting 8 of 12 fields, causing incomplete data on the dashboard audit page
- Expanded the `AuditInvocationEvent` interface in `src/events/event-bus.ts` to include `cacheReadTokens`, `cacheCreationTokens`, `inputSummary`, `outputSummary`
- Added those 4 fields to the `bus.emit()` call in `wireEventBus()` in `packages/dashboard/src/server/index.ts`

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] `npx vitest run` — all tests pass (2 pre-existing failures in `tests/chat/e2e.test.ts` unrelated to this change)
- [ ] Manual: open audit page, trigger an agent invocation, verify all 12 fields appear in the SSE event payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)