### PR TITLE
fix: save/restore HIVE_DAEMON_SPAWN in runCli test helper

### DIFF
--- a/tests/chat/e2e.test.ts
+++ b/tests/chat/e2e.test.ts
@@ -25,7 +25,9 @@ function seedPeople(db: ChatDb) {
  */
 async function runCli(deps: ChatCliDeps, args: string[], agentId: string = '1'): Promise<string> {
   const oldEnv = process.env.HIVE_AGENT_ID;
+  const oldDaemonSpawn = process.env.HIVE_DAEMON_SPAWN;
   process.env.HIVE_AGENT_ID = agentId;
+  delete process.env.HIVE_DAEMON_SPAWN;
 
   const program = new Command();
   program.exitOverride();
@@ -45,6 +47,8 @@ async function runCli(deps: ChatCliDeps, args: string[], agentId: string = '1'):
   } finally {
     process.stdout.write = origWrite;
     process.env.HIVE_AGENT_ID = oldEnv;
+    if (oldDaemonSpawn !== undefined) process.env.HIVE_DAEMON_SPAWN = oldDaemonSpawn;
+    else delete process.env.HIVE_DAEMON_SPAWN;
   }
 }
 


### PR DESCRIPTION
## Summary
- The `runCli` test helper in `tests/chat/e2e.test.ts` saved/restored `HIVE_AGENT_ID` but not `HIVE_DAEMON_SPAWN`
- When tests run inside a daemon-spawned context, the ack command hit the early-return guard at `cli.ts:118` and became a no-op, causing 2 ack tests to fail
- Fix: save `HIVE_DAEMON_SPAWN` at start, delete it during test execution, restore in the `finally` block

## Test plan
- [x] All 14 tests in `tests/chat/e2e.test.ts` pass (previously 2 failing)
- [x] Change is isolated to test helper — no production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)