### PR TITLE
fix: post-merge bug fixes for conversations redesign (#57)

### DIFF
--- a/packages/dashboard/src/client/pages/ConversationViewPage.tsx
+++ b/packages/dashboard/src/client/pages/ConversationViewPage.tsx
@@ -34,10 +34,23 @@ export function ConversationViewPage() {
   // Determine the focused sender alias for right-aligning their messages
   const focusedSender = hasFocalAgent ? agentAlias : undefined;
 
-  // Build breadcrumb pieces
+  // Build display names for breadcrumb and title
   const conversationDisplayName = conversation
     ? formatConversationName(conversation.name, agentMap, conversation.members, conversation.displayName)
     : conversationId;
+
+  // For breadcrumb: show conversation partner name (not focal agent) for DMs
+  const breadcrumbLabel = useMemo(() => {
+    if (!conversation || !hasFocalAgent || conversation.type !== 'dm') return conversationDisplayName;
+    // Find the other party in this DM
+    const otherAlias = conversation.members.find(m => m !== agentAlias && m !== 'super-user');
+    if (otherAlias) {
+      const other = agentMap.get(otherAlias);
+      if (other) return `@${other.name}`;
+      return `@${otherAlias}`;
+    }
+    return conversationDisplayName;
+  }, [conversation, hasFocalAgent, agentAlias, agentMap, conversationDisplayName]);
 
   // Loading state — wait for agents and conversations to resolve
   if (!agents || !conversations) {
@@ -62,7 +75,7 @@ export function ConversationViewPage() {
       <div className="flex flex-col items-center justify-center h-full gap-3">
         <p className="text-slate-400 text-sm">Conversation not found: <span className="text-slate-200 font-medium">{conversationId}</span></p>
         <Link
-          to={hasFocalAgent ? `/conversations` : '/conversations'}
+          to={hasFocalAgent ? `/conversations/${encodeURIComponent(agentAlias!)}` : '/conversations'}
           className="text-xs text-amber-500 hover:text-amber-400"
         >
           &larr; Back to Conversations
@@ -92,7 +105,7 @@ export function ConversationViewPage() {
             </>
           )}
           <span className="text-slate-600">/</span>
-          <span className="text-slate-400">{conversationDisplayName}</span>
+          <span className="text-slate-400">{breadcrumbLabel}</span>
         </nav>
 
         {/* Title row */}

--- a/packages/dashboard/src/client/pages/ConversationsDirectoryPage.tsx
+++ b/packages/dashboard/src/client/pages/ConversationsDirectoryPage.tsx
@@ -32,18 +32,22 @@ export function ConversationsDirectoryPage() {
     [agents]
   );
 
-  // Build per-agent stats: conversation count + last active timestamp
+  // Build per-agent stats: use server-provided conversationCount (agent-scoped) + last active from conversations
   const agentStats = useMemo(() => {
     const stats = new Map<string, { conversationCount: number; lastActive: string | null }>();
-    if (!agents || !conversations) return stats;
+    if (!agents) return stats;
     for (const agent of agents) {
-      const agentConvs = conversations.filter(c => c.members.includes(agent.id));
+      // conversationCount comes from the server using agent-scoped access control
+      const conversationCount = agent.conversationCount ?? 0;
       let lastActive: string | null = null;
-      for (const conv of agentConvs) {
-        const ts = conv.lastMessage?.timestamp;
-        if (ts && (!lastActive || ts > lastActive)) lastActive = ts;
+      if (conversations) {
+        for (const conv of conversations) {
+          if (!conv.members.includes(agent.id)) continue;
+          const ts = conv.lastMessage?.timestamp;
+          if (ts && (!lastActive || ts > lastActive)) lastActive = ts;
+        }
       }
-      stats.set(agent.id, { conversationCount: agentConvs.length, lastActive });
+      stats.set(agent.id, { conversationCount, lastActive });
     }
     return stats;
   }, [agents, conversations]);

--- a/packages/dashboard/src/client/types.ts
+++ b/packages/dashboard/src/client/types.ts
@@ -8,6 +8,7 @@ export interface Agent {
   lastHeartbeat?: string;
   lastInvocation?: string;
   currentTask?: string;
+  conversationCount?: number;
 }
 
 export interface OrgAgent {

--- a/packages/dashboard/src/server/routes/org.ts
+++ b/packages/dashboard/src/server/routes/org.ts
@@ -68,11 +68,17 @@ export function createOrgRoutes(ctx: HiveContext): Router {
 export function createAgentRoutes(ctx: HiveContext): Router {
   const router = Router();
 
-  // GET /api/agents — all agent states
+  // GET /api/agents — all agent states (includes per-agent conversation counts via agent-scoped access)
   router.get('/', (_req, res) => {
     const states = ctx.state.listAll();
     const agents = Array.from(ctx.orgChart.agents.values()).map(a => {
       const state = states.find(s => s.agentId === a.person.alias);
+      // Use agent-scoped access to count conversations (matches Layer 2's endpoint)
+      let conversationCount = 0;
+      try {
+        const personId = ctx.chatAdapter.resolveAlias(a.person.alias);
+        conversationCount = ctx.access.getAccessibleConversations(personId).length;
+      } catch { /* agent not in chat system yet */ }
       return {
         id: a.person.alias,
         name: a.identity.name,
@@ -83,6 +89,7 @@ export function createAgentRoutes(ctx: HiveContext): Router {
         lastHeartbeat: state?.lastHeartbeat,
         lastInvocation: state?.lastInvocation,
         currentTask: state?.currentTask,
+        conversationCount,
       };
     });
     res.json(agents);


### PR DESCRIPTION
## Summary
- **CRITICAL**: Layer 1 conversation counts were wrong — used super-user-scoped `/api/conversations` instead of agent-scoped access. Server now returns `conversationCount` per agent in `/api/agents` using proper agent-scoped access control, matching Layer 2's behavior.
- **HIGH**: Layer 3 breadcrumb showed the full conversation name (e.g. "Alice ↔ Bob") instead of the conversation partner. Now shows `@partnerName` for DMs with a focal agent.
- **MINOR**: 404 back-link always went to Layer 1. Now correctly links to Layer 2 when a focal agent is present.

## Files changed
- `packages/dashboard/src/server/routes/org.ts` — Added `conversationCount` to `/api/agents` response
- `packages/dashboard/src/client/types.ts` — Added `conversationCount` to Agent interface
- `packages/dashboard/src/client/pages/ConversationsDirectoryPage.tsx` — Uses server-provided count instead of client-side filtering
- `packages/dashboard/src/client/pages/ConversationViewPage.tsx` — Fixed breadcrumb label + 404 back-link

## Test plan
- [x] All 403 tests pass (`npx vitest run`)
- [x] Vite build succeeds
- [ ] Tess: verify Layer 1 counts match Layer 2 counts for each agent
- [ ] Tess: verify breadcrumb shows `Conversations > Agent > @partner` for DMs
- [ ] Tess: verify 404 back-link goes to Layer 2 when focal agent present

🤖 Generated with [Claude Code](https://claude.com/claude-code)